### PR TITLE
feat: [003-EMAIL-VERIFICATION] 커스터머 이메일 인증기능 구현

### DIFF
--- a/user-api/build.gradle
+++ b/user-api/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'org.springframework.data:spring-data-envers'
 
+	implementation 'org.apache.commons:commons-lang3:3.13.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/user-api/src/main/java/com/zerobase/cms/user/application/SignUpApplication.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/application/SignUpApplication.java
@@ -1,0 +1,63 @@
+package com.zerobase.cms.user.application;
+
+import com.zerobase.cms.user.client.MailgunClient;
+import com.zerobase.cms.user.client.mailgun.SendMailForm;
+import com.zerobase.cms.user.domain.SignUpForm;
+import com.zerobase.cms.user.domain.model.Customer;
+import com.zerobase.cms.user.exception.CustomException;
+import com.zerobase.cms.user.exception.ErrorCode;
+import com.zerobase.cms.user.service.SignUpCustomerService;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpApplication {
+    private final MailgunClient mailgunClient;
+    private final SignUpCustomerService signUpCustomerService;
+
+    public void customerVerify(String email, String code) {
+        signUpCustomerService.verifyEmail(email, code);
+    }
+    public String customerSignUp(SignUpForm form) {
+        if (signUpCustomerService.isEmailExist(form.getEmail())) {
+            // 이미 가입된 상태는 가입을 할 필요 없음
+            throw new CustomException(ErrorCode.ALREADY_REGISTERED_USER);
+        } else {
+            Customer customer = signUpCustomerService.signUp(form);
+            LocalDateTime now = LocalDateTime.now();
+
+            String code = getRandomCode();
+
+            SendMailForm sendMailForm = SendMailForm.builder()
+                    .from("tester@email.com")
+                    .to(form.getEmail())
+                    .subject("Account Verification")
+                     .text(getVerificationEmailBody(form.getEmail(), form.getName(), code))
+                    .build();
+
+            mailgunClient.sendEmail(sendMailForm);
+            signUpCustomerService.changeCustomerValidateEmail(customer.getId(), code);
+
+            return "회원가입 완료";
+        }
+    }
+
+    private String getRandomCode() {
+        return RandomStringUtils.random(10, true, true);
+    }
+
+    private String getVerificationEmailBody(String email, String name, String code) {
+        StringBuilder builder = new StringBuilder();
+        return builder.append("안녕하세요 ").append(name)
+                .append("!\n아래 링크를 눌러주세요.\n\n")
+                .append("http://localhost:8080/signup/verify/customer?email=")
+                .append(email)
+                .append("&code=")
+                .append(code).toString();
+    }
+
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/client/MailgunClient.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/MailgunClient.java
@@ -11,6 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Qualifier("mailgun")
 public interface MailgunClient {
 
-    @PostMapping("sandbox52bcc7ca4f2c435aac630a8fd9973333.mailgun.org/messages")
+    @PostMapping("${mailgun-domain}")
     ResponseEntity<String> sendEmail(@SpringQueryMap SendMailForm form);
 }

--- a/user-api/src/main/java/com/zerobase/cms/user/domain/model/Customer.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/domain/model/Customer.java
@@ -2,17 +2,14 @@ package com.zerobase.cms.user.domain.model;
 
 import com.zerobase.cms.user.domain.SignUpForm;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Locale;
 
-@Getter
+@Getter @Setter
 @Entity
 @Builder
 @NoArgsConstructor

--- a/user-api/src/main/java/com/zerobase/cms/user/domain/repository/CustomerRepository.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/domain/repository/CustomerRepository.java
@@ -4,6 +4,9 @@ import com.zerobase.cms.user.domain.model.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+    Optional<Customer> findByEmail(String email);
 }

--- a/user-api/src/main/java/com/zerobase/cms/user/exception/CustomException.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.zerobase.cms.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getDetail());
+        this.errorCode = errorCode;
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/exception/ErrorCode.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.zerobase.cms.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+    ALREADY_REGISTERED_USER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
+    WRONG_VERIFICATION(HttpStatus.BAD_REQUEST, "잘못된 인증 시도입니다."),
+    EXPIRE_CODE(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "일치하는 회원이 없습니다."),
+    ALREADY_VERIFY(HttpStatus.BAD_REQUEST, "이미 인증이 완료되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String detail;
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/exception/ExceptionController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/exception/ExceptionController.java
@@ -1,0 +1,35 @@
+package com.zerobase.cms.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class ExceptionController {
+
+    @ExceptionHandler({
+            CustomException.class
+    })
+    public ResponseEntity<ExceptionResponse> customRequestException(
+            final CustomException customException) {
+        log.warn("api Exception : {}", customException.getErrorCode());
+
+        return ResponseEntity.badRequest().body(new ExceptionResponse(
+                customException.getMessage(), customException.getErrorCode()
+        ));
+    }
+
+    @Getter
+    @ToString
+    @AllArgsConstructor
+    public static class ExceptionResponse {
+        private String message;
+        private ErrorCode errorCode;
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/service/SignUpCustomerService.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/service/SignUpCustomerService.java
@@ -3,8 +3,17 @@ package com.zerobase.cms.user.service;
 import com.zerobase.cms.user.domain.SignUpForm;
 import com.zerobase.cms.user.domain.model.Customer;
 import com.zerobase.cms.user.domain.repository.CustomerRepository;
+import com.zerobase.cms.user.exception.CustomException;
+import com.zerobase.cms.user.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.zerobase.cms.user.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +23,42 @@ public class SignUpCustomerService {
 
     public Customer signUp(SignUpForm form) {
         return customerRepository.save(Customer.from(form));
+    }
+
+    public boolean isEmailExist(String email) {
+        email = email.toLowerCase(Locale.ROOT);
+        return customerRepository.findByEmail(email).isPresent();
+    }
+
+    @Transactional
+    public void verifyEmail(String email, String code) {
+        Customer customer = customerRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if (customer.isVerify()) {
+            throw new CustomException(ALREADY_VERIFY);
+        }
+        if (!customer.getVerificationCode().equals(code)) {
+            throw new CustomException(WRONG_VERIFICATION);
+        }
+        if (customer.getVerifyExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new CustomException(EXPIRE_CODE);
+        }
+        customer.setVerify(true);
+    }
+
+    @Transactional
+    public LocalDateTime changeCustomerValidateEmail(Long customerId, String verificationCode) {
+        Optional<Customer> customerOptional = customerRepository.findById(customerId);
+
+        if (customerOptional.isEmpty()) {
+            throw new CustomException(USER_NOT_FOUND);
+        } else {
+            Customer customer = customerOptional.get();
+            customer.setVerificationCode(verificationCode);
+            customer.setVerifyExpiredAt(LocalDateTime.now().plusHours(2));
+
+            return customer.getVerifyExpiredAt();
+        }
     }
 }

--- a/user-api/src/main/java/com/zerobase/cms/user/web_controller/SignUpController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/web_controller/SignUpController.java
@@ -1,0 +1,26 @@
+package com.zerobase.cms.user.web_controller;
+
+import com.zerobase.cms.user.application.SignUpApplication;
+import com.zerobase.cms.user.domain.SignUpForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/signup")
+@RequiredArgsConstructor
+public class SignUpController {
+
+    private final SignUpApplication signUpApplication;
+
+    @PostMapping
+    public ResponseEntity<String> customerSignUp(@RequestBody SignUpForm form) {
+        return ResponseEntity.ok(signUpApplication.customerSignUp(form));
+    }
+
+    @PutMapping("/verify/customer")
+    public ResponseEntity<String> verifyCustomer(String email, String code) {
+        signUpApplication.customerVerify(email, code);
+        return ResponseEntity.ok("인증이 완료되었습니다.");
+    }
+}

--- a/user-api/src/main/resources/application.properties
+++ b/user-api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port=8081
+server.port=8080
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 spring.cloud.openfeign.okhttp.enabled=true
 spring.datasource.url=jdbc:mysql://localhost:3306/zeroorder?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true


### PR DESCRIPTION
## Changes

1. 회원가입시 인증번호 포함한 이메일 발송: 유효기간 1일
2. 발송된 이메일 링크 클릭 시 로그인 기능


## Background
1. Key가 노출될 경우 Mailgun에서 Github에 Scan을 걸어 자동으로 블락 시킴.
2. 이메일 링크 클릭시 현시점 405(Method Not Allowed) 에러 발생
    - PutMapping 이기 때문에 발생하는 것으로 보임
